### PR TITLE
Fix Spaces being created and moved before reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ Additionally, a hotkey can be bound (`space_chooser`) which will toggle a Spotli
 * When a space is moved in Mission Control, its position will be updated in the menu
 * Space names are persisted left-to-right in Hammerspoon settings between loads
 
-# Known Issues
-
-* Creating a Space in Mission Control and moving it to a position other than the end before entering it will cause it to overwrite the name of the Space at that position
-  * This can be avoided by just being sure to enter into a Space after creation before moving it
-
 # Installation
 
 ## Automated

--- a/docs.json
+++ b/docs.json
@@ -2,12 +2,12 @@
   {
     "Constant" : [
       {
-        "def" : "Spacer.settingsKey",
+        "doc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
         "stripped_doc" : [
           "Key used for persisting space names between Hammerspoon launches via hs.settings."
         ],
-        "doc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
         "desc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
+        "def" : "Spacer.settingsKey",
         "notes" : [
 
         ],
@@ -30,12 +30,12 @@
     ],
     "Variable" : [
       {
-        "def" : "Spacer.defaultHotkeys",
+        "doc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
         "stripped_doc" : [
           "Default hotkey to use for the space chooser when \"hotkeys\" ="
         ],
-        "doc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
         "desc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
+        "def" : "Spacer.defaultHotkeys",
         "notes" : [
 
         ],
@@ -50,13 +50,13 @@
         ]
       },
       {
-        "def" : "Spacer.logger",
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "stripped_doc" : [
           "Logger object used within the Spoon. Can be accessed to set the default log ",
           "level for the messages coming from the Spoon."
         ],
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "def" : "Spacer.logger",
         "notes" : [
 
         ],
@@ -71,12 +71,12 @@
         ]
       },
       {
-        "def" : "Spacer.logLevel",
+        "doc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
         "stripped_doc" : [
           "Spacer specific log level override, see hs.logger.setLogLevel for options."
         ],
-        "doc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
         "desc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
+        "def" : "Spacer.logLevel",
         "notes" : [
 
         ],
@@ -91,12 +91,12 @@
         ]
       },
       {
-        "def" : "Spacer.menuBar",
+        "doc" : "hs.menubar representing the menu bar for Spacer.",
         "stripped_doc" : [
           "hs.menubar representing the menu bar for Spacer."
         ],
-        "doc" : "hs.menubar representing the menu bar for Spacer.",
         "desc" : "hs.menubar representing the menu bar for Spacer.",
+        "def" : "Spacer.menuBar",
         "notes" : [
 
         ],
@@ -111,12 +111,12 @@
         ]
       },
       {
-        "def" : "Spacer.spaceWatcher",
+        "doc" : "hs.spaces.watcher instance used for monitoring for space changes.",
         "stripped_doc" : [
           "hs.spaces.watcher instance used for monitoring for space changes."
         ],
-        "doc" : "hs.spaces.watcher instance used for monitoring for space changes.",
         "desc" : "hs.spaces.watcher instance used for monitoring for space changes.",
+        "def" : "Spacer.spaceWatcher",
         "notes" : [
 
         ],
@@ -131,12 +131,12 @@
         ]
       },
       {
-        "def" : "Spacer.spaceNames",
+        "doc" : "Table with key-value mapping of Space ID to it's user set name.",
         "stripped_doc" : [
           "Table with key-value mapping of Space ID to it's user set name."
         ],
-        "doc" : "Table with key-value mapping of Space ID to it's user set name.",
         "desc" : "Table with key-value mapping of Space ID to it's user set name.",
+        "def" : "Spacer.spaceNames",
         "notes" : [
 
         ],
@@ -151,13 +151,13 @@
         ]
       },
       {
-        "def" : "Spacer.orderedSpaces",
+        "doc" : "Table holding an ordered list of space IDs, which is then used to resolve\nactual space names for IDs from Spacer.spaceNames.",
         "stripped_doc" : [
           "Table holding an ordered list of space IDs, which is then used to resolve",
           "actual space names for IDs from Spacer.spaceNames."
         ],
-        "doc" : "Table holding an ordered list of space IDs, which is then used to resolve\nactual space names for IDs from Spacer.spaceNames.",
         "desc" : "Table holding an ordered list of space IDs, which is then used to resolve",
+        "def" : "Spacer.orderedSpaces",
         "notes" : [
 
         ],
@@ -172,13 +172,13 @@
         ]
       },
       {
-        "def" : "Spacer.orderedSpaceNames",
+        "doc" : "Table with an ordered list of the space names, which is used when loading\nthe menubar, as well as persisted to and from hs.settings between loads.",
         "stripped_doc" : [
           "Table with an ordered list of the space names, which is used when loading",
           "the menubar, as well as persisted to and from hs.settings between loads."
         ],
-        "doc" : "Table with an ordered list of the space names, which is used when loading\nthe menubar, as well as persisted to and from hs.settings between loads.",
         "desc" : "Table with an ordered list of the space names, which is used when loading",
+        "def" : "Spacer.orderedSpaceNames",
         "notes" : [
 
         ],
@@ -193,12 +193,12 @@
         ]
       },
       {
-        "def" : "Spacer.focusedSpace",
+        "doc" : "int with the ID of the currently focused space.",
         "stripped_doc" : [
           "int with the ID of the currently focused space."
         ],
-        "doc" : "int with the ID of the currently focused space.",
         "desc" : "int with the ID of the currently focused space.",
+        "def" : "Spacer.focusedSpace",
         "notes" : [
 
         ],
@@ -213,12 +213,12 @@
         ]
       },
       {
-        "def" : "Spacer.spaceChooser",
+        "doc" : "hs.chooser object representing the Space chooser.",
         "stripped_doc" : [
           "hs.chooser object representing the Space chooser."
         ],
-        "doc" : "hs.chooser object representing the Space chooser.",
         "desc" : "hs.chooser object representing the Space chooser.",
+        "def" : "Spacer.spaceChooser",
         "notes" : [
 
         ],
@@ -239,21 +239,21 @@
     "Deprecated" : [
 
     ],
-    "type" : "Module",
     "desc" : "Name and switch Mission Control spaces in the menu bar",
+    "type" : "Module",
     "Constructor" : [
 
     ],
     "doc" : "Name and switch Mission Control spaces in the menu bar\n\nDownload: [Spacer.spoon.zip](https:\/\/github.com\/adammillerio\/Spoons\/raw\/main\/Spoons\/Spacer.spoon.zip)\n\nREADME: [README.md](https:\/\/github.com\/adammillerio\/Spacer.spoon\/blob\/main\/README.md)\n\nSpace names can be changed from the menubar by holding Alt while selecting\nthe desired space to rename. These are persisted between launches via the\nhs.settings module.",
     "Method" : [
       {
-        "def" : "Spacer:init()",
+        "doc" : "Spoon initializer method for Spacer.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon initializer method for Spacer.",
           ""
         ],
-        "doc" : "Spoon initializer method for Spacer.\n\nParameters:\n * None\n\nReturns:\n * None",
         "desc" : "Spoon initializer method for Spacer.",
+        "def" : "Spacer:init()",
         "notes" : [
 
         ],
@@ -269,13 +269,13 @@
         ]
       },
       {
-        "def" : "Spacer:start()",
+        "doc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.",
           ""
         ],
-        "doc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
         "desc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.",
+        "def" : "Spacer:start()",
         "notes" : [
 
         ],
@@ -291,307 +291,13 @@
         ]
       },
       {
-        "def" : "Spacer:stop()",
+        "doc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.",
           ""
         ],
-        "doc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
         "desc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer:stop()",
-        "type" : "Method",
-        "returns" : [
-          " * None"
-        ],
-        "name" : "stop",
-        "parameters" : [
-          " * None",
-          ""
-        ]
-      }
-    ],
-    "Field" : [
-
-    ],
-    "items" : [
-      {
-        "def" : "Spacer.settingsKey",
-        "stripped_doc" : [
-          "Key used for persisting space names between Hammerspoon launches via hs.settings."
-        ],
-        "doc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
-        "desc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.settingsKey",
-        "type" : "Constant",
-        "returns" : [
-
-        ],
-        "name" : "settingsKey",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.defaultHotkeys",
-        "stripped_doc" : [
-          "Default hotkey to use for the space chooser when \"hotkeys\" ="
-        ],
-        "doc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
-        "desc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.defaultHotkeys",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "defaultHotkeys",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.focusedSpace",
-        "stripped_doc" : [
-          "int with the ID of the currently focused space."
-        ],
-        "doc" : "int with the ID of the currently focused space.",
-        "desc" : "int with the ID of the currently focused space.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.focusedSpace",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "focusedSpace",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.logLevel",
-        "stripped_doc" : [
-          "Spacer specific log level override, see hs.logger.setLogLevel for options."
-        ],
-        "doc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
-        "desc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.logLevel",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "logLevel",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.logger",
-        "stripped_doc" : [
-          "Logger object used within the Spoon. Can be accessed to set the default log ",
-          "level for the messages coming from the Spoon."
-        ],
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.logger",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "logger",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.menuBar",
-        "stripped_doc" : [
-          "hs.menubar representing the menu bar for Spacer."
-        ],
-        "doc" : "hs.menubar representing the menu bar for Spacer.",
-        "desc" : "hs.menubar representing the menu bar for Spacer.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.menuBar",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "menuBar",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.orderedSpaceNames",
-        "stripped_doc" : [
-          "Table with an ordered list of the space names, which is used when loading",
-          "the menubar, as well as persisted to and from hs.settings between loads."
-        ],
-        "doc" : "Table with an ordered list of the space names, which is used when loading\nthe menubar, as well as persisted to and from hs.settings between loads.",
-        "desc" : "Table with an ordered list of the space names, which is used when loading",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.orderedSpaceNames",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "orderedSpaceNames",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.orderedSpaces",
-        "stripped_doc" : [
-          "Table holding an ordered list of space IDs, which is then used to resolve",
-          "actual space names for IDs from Spacer.spaceNames."
-        ],
-        "doc" : "Table holding an ordered list of space IDs, which is then used to resolve\nactual space names for IDs from Spacer.spaceNames.",
-        "desc" : "Table holding an ordered list of space IDs, which is then used to resolve",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.orderedSpaces",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "orderedSpaces",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.spaceChooser",
-        "stripped_doc" : [
-          "hs.chooser object representing the Space chooser."
-        ],
-        "doc" : "hs.chooser object representing the Space chooser.",
-        "desc" : "hs.chooser object representing the Space chooser.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.spaceChooser",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "spaceChooser",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.spaceNames",
-        "stripped_doc" : [
-          "Table with key-value mapping of Space ID to it's user set name."
-        ],
-        "doc" : "Table with key-value mapping of Space ID to it's user set name.",
-        "desc" : "Table with key-value mapping of Space ID to it's user set name.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.spaceNames",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "spaceNames",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer.spaceWatcher",
-        "stripped_doc" : [
-          "hs.spaces.watcher instance used for monitoring for space changes."
-        ],
-        "doc" : "hs.spaces.watcher instance used for monitoring for space changes.",
-        "desc" : "hs.spaces.watcher instance used for monitoring for space changes.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer.spaceWatcher",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "name" : "spaceWatcher",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "Spacer:init()",
-        "stripped_doc" : [
-          "Spoon initializer method for Spacer.",
-          ""
-        ],
-        "doc" : "Spoon initializer method for Spacer.\n\nParameters:\n * None\n\nReturns:\n * None",
-        "desc" : "Spoon initializer method for Spacer.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer:init()",
-        "type" : "Method",
-        "returns" : [
-          " * None"
-        ],
-        "name" : "init",
-        "parameters" : [
-          " * None",
-          ""
-        ]
-      },
-      {
-        "def" : "Spacer:start()",
-        "stripped_doc" : [
-          "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.",
-          ""
-        ],
-        "doc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
-        "desc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.",
-        "notes" : [
-
-        ],
-        "signature" : "Spacer:start()",
-        "type" : "Method",
-        "returns" : [
-          " * None"
-        ],
-        "name" : "start",
-        "parameters" : [
-          " * None",
-          ""
-        ]
-      },
-      {
         "def" : "Spacer:stop()",
-        "stripped_doc" : [
-          "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.",
-          ""
-        ],
-        "doc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
-        "desc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.",
         "notes" : [
 
         ],
@@ -609,6 +315,300 @@
     ],
     "Command" : [
 
+    ],
+    "Field" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
+        "stripped_doc" : [
+          "Key used for persisting space names between Hammerspoon launches via hs.settings."
+        ],
+        "desc" : "Key used for persisting space names between Hammerspoon launches via hs.settings.",
+        "def" : "Spacer.settingsKey",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.settingsKey",
+        "type" : "Constant",
+        "returns" : [
+
+        ],
+        "name" : "settingsKey",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
+        "stripped_doc" : [
+          "Default hotkey to use for the space chooser when \"hotkeys\" ="
+        ],
+        "desc" : "Default hotkey to use for the space chooser when \"hotkeys\" =",
+        "def" : "Spacer.defaultHotkeys",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.defaultHotkeys",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "defaultHotkeys",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "int with the ID of the currently focused space.",
+        "stripped_doc" : [
+          "int with the ID of the currently focused space."
+        ],
+        "desc" : "int with the ID of the currently focused space.",
+        "def" : "Spacer.focusedSpace",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.focusedSpace",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "focusedSpace",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
+        "stripped_doc" : [
+          "Spacer specific log level override, see hs.logger.setLogLevel for options."
+        ],
+        "desc" : "Spacer specific log level override, see hs.logger.setLogLevel for options.",
+        "def" : "Spacer.logLevel",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.logLevel",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "logLevel",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log ",
+          "level for the messages coming from the Spoon."
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "def" : "Spacer.logger",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "logger",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "hs.menubar representing the menu bar for Spacer.",
+        "stripped_doc" : [
+          "hs.menubar representing the menu bar for Spacer."
+        ],
+        "desc" : "hs.menubar representing the menu bar for Spacer.",
+        "def" : "Spacer.menuBar",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.menuBar",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "menuBar",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Table with an ordered list of the space names, which is used when loading\nthe menubar, as well as persisted to and from hs.settings between loads.",
+        "stripped_doc" : [
+          "Table with an ordered list of the space names, which is used when loading",
+          "the menubar, as well as persisted to and from hs.settings between loads."
+        ],
+        "desc" : "Table with an ordered list of the space names, which is used when loading",
+        "def" : "Spacer.orderedSpaceNames",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.orderedSpaceNames",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "orderedSpaceNames",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Table holding an ordered list of space IDs, which is then used to resolve\nactual space names for IDs from Spacer.spaceNames.",
+        "stripped_doc" : [
+          "Table holding an ordered list of space IDs, which is then used to resolve",
+          "actual space names for IDs from Spacer.spaceNames."
+        ],
+        "desc" : "Table holding an ordered list of space IDs, which is then used to resolve",
+        "def" : "Spacer.orderedSpaces",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.orderedSpaces",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "orderedSpaces",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "hs.chooser object representing the Space chooser.",
+        "stripped_doc" : [
+          "hs.chooser object representing the Space chooser."
+        ],
+        "desc" : "hs.chooser object representing the Space chooser.",
+        "def" : "Spacer.spaceChooser",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.spaceChooser",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "spaceChooser",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Table with key-value mapping of Space ID to it's user set name.",
+        "stripped_doc" : [
+          "Table with key-value mapping of Space ID to it's user set name."
+        ],
+        "desc" : "Table with key-value mapping of Space ID to it's user set name.",
+        "def" : "Spacer.spaceNames",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.spaceNames",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "spaceNames",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "hs.spaces.watcher instance used for monitoring for space changes.",
+        "stripped_doc" : [
+          "hs.spaces.watcher instance used for monitoring for space changes."
+        ],
+        "desc" : "hs.spaces.watcher instance used for monitoring for space changes.",
+        "def" : "Spacer.spaceWatcher",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer.spaceWatcher",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "spaceWatcher",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Spoon initializer method for Spacer.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "stripped_doc" : [
+          "Spoon initializer method for Spacer.",
+          ""
+        ],
+        "desc" : "Spoon initializer method for Spacer.",
+        "def" : "Spacer:init()",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer:init()",
+        "type" : "Method",
+        "returns" : [
+          " * None"
+        ],
+        "name" : "init",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "doc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "stripped_doc" : [
+          "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.",
+          ""
+        ],
+        "desc" : "Spoon start method for Spacer. Creates\/starts menu bar item and space watcher.",
+        "def" : "Spacer:start()",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer:start()",
+        "type" : "Method",
+        "returns" : [
+          " * None"
+        ],
+        "name" : "start",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "doc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "stripped_doc" : [
+          "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.",
+          ""
+        ],
+        "desc" : "Spoon stop method for Spacer. Deletes menu bar item and stops space watcher.",
+        "def" : "Spacer:stop()",
+        "notes" : [
+
+        ],
+        "signature" : "Spacer:stop()",
+        "type" : "Method",
+        "returns" : [
+          " * None"
+        ],
+        "name" : "stop",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      }
     ],
     "name" : "Spacer"
   }

--- a/init.lua
+++ b/init.lua
@@ -95,7 +95,7 @@ function Spacer:_menuItemClicked(spacePos, spaceID, modifiers, menuItem)
         self:_renameSpace(spacePos, spaceID, inputSpaceName)
         self:_setMenuText()
     else
-        if spaceID ~= self.focusedSpace then        
+        if spaceID ~= self.focusedSpace then
             -- Go to the selected space if it is not the current one.
             hs.spaces.gotoSpace(spaceID)
         end
@@ -168,17 +168,28 @@ end
 
 -- Load a new space into Spacer, resolving either it's previously persisted
 -- ordinal name, or initializing it to "None".
-function Spacer:_loadNewSpace(spacePos, spaceID)
+function Spacer:_loadNewSpace(spacePos, spaceID, initial)
     self.logger.vf("Creating new space at \"Desktop %d\" with ID %d", spacePos,
                    spaceID)
 
-    -- See if there was a name for the space in this position last load.
-    spaceName = self.orderedSpaceNames[spacePos]
-    if spaceName == nil then
-        -- No previous name in position, default space name to "None" and insert
-        -- it into the table.
-        spaceName = "None"
-        table.insert(self.orderedSpaceNames, spaceName)
+    if initial then
+        -- See if there was a name for the space in this position last load.
+        spaceName = self.orderedSpaceNames[spacePos]
+        if spaceName == nil then
+            -- No previous name in position, default space name to "None" and insert
+            -- it into the table.
+            spaceName = "None"
+            self.orderedSpaceNames[spacePos] = spaceName
+        end
+    else
+        -- See if there's already a name stored for this space and use if there is.
+        spaceName = self.spaceNames[spaceID]
+        if spaceName == nil then
+            -- No previous name in position, default space name to "None" and insert
+            -- it into the table.
+            spaceName = "None"
+            self.orderedSpaceNames[spacePos] = spaceName
+        end
     end
 
     self.logger.vf("Setting name for \"Desktop %d\" to \"%s\"", spacePos,
@@ -211,39 +222,47 @@ function Spacer:_reloadSpaceNames()
     -- Get the spaces for this screen.
     screenSpaces = spaces[screen:getUUID()]
 
-    -- Step 1: Retrieve the number of spaces we had before making any changes
+    -- Retrieve the number of spaces we had before making any changes
     existingNumSpaces = #self.orderedSpaces
     self.logger.vf("Existing number of spaces is %d", existingNumSpaces)
 
     -- For every numerical index i and spaceID for spaces on this screen, from left
     -- to right.
     for i, spaceID in ipairs(screenSpaces) do
-        -- Step 2: Retrieve ID of the space that was in this this position last time
+        -- Retrieve ID of the space that was in this this position last time
         self.logger.vf("Getting existing space ID for Desktop %d", i)
         existingSpaceID = self.orderedSpaces[i]
         self.logger.vf("Existing space ID for Desktop %d: %s", i,
                        existingSpaceID)
 
-        -- Step 3: If there was no ID in this position, then this is a newly
+        -- If there was no ID in this position, then this is a newly
         --  created space in the rightmost position, so initialize and append it
         --  to the orderedSpaces and continue iteration.
         if existingSpaceID == nil then
-            -- New space at end, append
-            self:_loadNewSpace(i, spaceID)
+            -- New space at end, append.
+            self:_loadNewSpace(i, spaceID, false)
 
             changed = true
             goto continue
         end
 
-        -- Step 4: Look up the assigned name for this space ID
+        -- Look up the assigned name for this space ID
         self.logger.vf("Getting existing space name for Desktop %d", i)
         existingSpaceName = self.spaceNames[existingSpaceID]
         self.logger.vf("Existing space name for Desktop %d: %s", i,
                        existingSpaceName)
 
-        -- Step 5: Load the space name for the ID at this index during this run
+        -- Load the space name for the ID at this index during this run
         spaceName = self.spaceNames[spaceID]
-        -- Step 6: If the resolved name now does not match the resolved name from
+        if spaceName == nil then
+            -- New space not at end, append.
+            self:_loadNewSpace(i, spaceID, false)
+
+            changed = true
+            goto continue
+        end
+
+        -- If the resolved name now does not match the resolved name from
         --  last run, then update the ordered left-to-right set of space IDs at
         --  this index to now be the ID of the current space in this position. Also
         --  update the ordered name to the same thing.
@@ -260,7 +279,7 @@ function Spacer:_reloadSpaceNames()
         ::continue::
     end
 
-    -- Step 7: Check if the new number of spaces we have is less than the old
+    -- Check if the new number of spaces we have is less than the old
     --  one, if it is, then remove all extra indices in the orderedSpaces table.
     numSpaces = #screenSpaces
     self.logger.vf("New number of spaces is %d", numSpaces)
@@ -312,7 +331,7 @@ function Spacer:_loadSpaceNames()
     -- Iterate through spaces by index, this gives them to us from left to right.
     for i, spaceID in ipairs(screenSpaces) do
         -- Load new space.
-        self:_loadNewSpace(i, spaceID)
+        self:_loadNewSpace(i, spaceID, true)
     end
 
     self.logger.vf("Loaded space names: %s", hs.inspect(self.orderedSpaceNames))

--- a/init.lua
+++ b/init.lua
@@ -14,7 +14,7 @@ Spacer.__index = Spacer
 
 -- Metadata
 Spacer.name = "Spacer"
-Spacer.version = "0.0.3"
+Spacer.version = "1.0.0"
 Spacer.author = "Adam Miller <adam@adammiller.io>"
 Spacer.homepage = "https://github.com/adammillerio/Spacer.spoon"
 Spacer.license = "MIT - https://opensource.org/licenses/MIT"
@@ -166,8 +166,9 @@ function Spacer:_spaceChanged(spaceID)
     self:_setMenuText()
 end
 
--- Load a new space into Spacer, resolving either it's previously persisted
--- ordinal name, or initializing it to "None".
+-- Load a new space into Spacer, resolving either it's current name if a new but
+-- moved space, outside of initial load, it's previous ordinal name at the current
+-- position if on initial load, or defaulting to "None".
 function Spacer:_loadNewSpace(spacePos, spaceID, initial)
     self.logger.vf("Creating new space at \"Desktop %d\" with ID %d", spacePos,
                    spaceID)


### PR DESCRIPTION
This fixes a bug where a Space that is created and moved before exiting Mission Control would cause the Space to be invisible and overwrite the Space name at the existing position on reload.